### PR TITLE
fix: disable auto-paste message to the user input

### DIFF
--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -784,10 +784,6 @@ function _Chat() {
   const onRightClick = (e: any, message: ChatMessage) => {
     // copy to clipboard
     if (selectOrCopy(e.currentTarget, message.content)) {
-      if (userInput.length === 0) {
-        setUserInput(message.content);
-      }
-
       e.preventDefault();
     }
   };


### PR DESCRIPTION
This is duplicate function to the copy mssage button. Also not very useful on mobile: the paste command is not easy to undo, bad for UX.